### PR TITLE
Add unit tests for toy GNFS modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+# Ensure project root is on sys.path so tests can import gnfs package
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+    sys.path.insert(0, ROOT)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,8 @@
+from gnfs import gnfs_factor
+import cli
+
+
+def test_cli_main_output(capsys):
+    cli.main(["10"])
+    captured = capsys.readouterr()
+    assert "Factors of 10: [2, 5]" in captured.out

--- a/tests/test_factor.py
+++ b/tests/test_factor.py
@@ -1,0 +1,5 @@
+from gnfs.factor import gnfs_factor
+
+
+def test_gnfs_factor_even_number():
+    assert gnfs_factor(10) == [2, 5]

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -1,0 +1,8 @@
+from gnfs.linear_algebra import solve_matrix
+from gnfs.sieve import Relation
+
+
+def test_solve_matrix_returns_indices():
+    relations = [Relation(a=i, b=1, value=i) for i in range(3)]
+    result = solve_matrix(relations)
+    assert result == [0, 1, 2]

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -1,0 +1,16 @@
+import pytest
+from gnfs.polynomial import Polynomial, select_polynomial
+
+
+def test_polynomial_evaluate_and_degree():
+    poly = Polynomial((1, 2, 3))
+    assert poly.degree() == 2
+    assert poly.evaluate(0) == 1
+    assert poly.evaluate(1) == 6
+    assert poly.evaluate(2) == 17
+
+
+def test_select_polynomial():
+    poly = select_polynomial(10)
+    assert isinstance(poly, Polynomial)
+    assert poly.coeffs == (-int(10 ** 0.5), 1)

--- a/tests/test_sieve.py
+++ b/tests/test_sieve.py
@@ -1,0 +1,23 @@
+import sympy as sp
+from gnfs.polynomial import Polynomial, select_polynomial
+from gnfs.sieve import _polynomial_roots_mod_p, find_relations
+
+
+def test_polynomial_roots_mod_p():
+    # x^2 - 1 mod 3 has roots 1 and 2
+    poly = Polynomial((-1, 0, 1))
+    roots = _polynomial_roots_mod_p(poly, 3)
+    assert set(roots) == {1, 2}
+
+
+def test_find_relations_produces_smooth_values():
+    poly = select_polynomial(10)
+    relations = list(find_relations(poly, bound=5, interval=5))
+    assert relations, "Expected at least one relation"
+    primes = list(sp.primerange(2, 6))
+    for rel in relations:
+        value = abs(rel.value)
+        for p in primes:
+            while value % p == 0 and value != 0:
+                value //= p
+        assert value == 1

--- a/tests/test_square_root.py
+++ b/tests/test_square_root.py
@@ -1,0 +1,8 @@
+from gnfs.square_root import find_factors
+from gnfs.sieve import Relation
+
+
+def test_find_factors_even_number():
+    relations = [Relation(a=0, b=1, value=1)]
+    factors = list(find_factors(10, relations))
+    assert factors == [2, 5]


### PR DESCRIPTION
## Summary
- add a `tests` package with pytest configuration
- cover polynomial utilities, sieve helpers, linear algebra, square-root stage and main factorization
- simple CLI test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686fdc0fafa8832ca86497079d01b935