### PR TITLE
Add CLI options with config file

### DIFF
--- a/FUTURE_TASKS.md
+++ b/FUTURE_TASKS.md
@@ -11,8 +11,8 @@ The current code base offers only a minimal demonstration. The tasks below break
 - ~~Update imports and tests to match the new layout.~~
 
 ## 3. Improve the CLI
-- Add command line options for polynomial degree, factor base size, and sieve range.
-- Provide a default configuration file.
+- ~~Add command line options for polynomial degree, factor base size, and sieve range.~~
+- ~~Provide a default configuration file.~~
 
 ## 4. Implement Polynomial Selection
 - Replace `select_polynomial` with heuristics for degree and coefficient search.

--- a/README.md
+++ b/README.md
@@ -21,4 +21,11 @@ python cli.py 30
 ```
 
 This will run the simplified GNFS pipeline and print the factors of the given
-number.
+number.  The CLI accepts a few optional arguments:
+
+```bash
+python cli.py 30 --degree 1 --bound 40 --interval 60
+```
+
+Values for ``degree``, ``bound`` and ``interval`` are loaded from
+``default_config.json`` if not specified on the command line.

--- a/cli.py
+++ b/cli.py
@@ -1,17 +1,38 @@
 """Command-line interface for the minimal GNFS demonstration."""
 
 import argparse
+import json
+from pathlib import Path
 import sys
 
 from gnfs import gnfs_factor
+
+DEFAULT_CONFIG = Path(__file__).with_name("default_config.json")
+
+
+def load_config(path: Path) -> dict:
+    """Load configuration options from ``path`` if it exists."""
+    if path.exists():
+        with path.open() as fh:
+            return json.load(fh)
+    return {}
 
 
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(description="Factor integers using a minimal GNFS")
     parser.add_argument("n", type=int, help="Integer to factor")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="Path to configuration file")
+    parser.add_argument("--degree", type=int, help="Polynomial degree")
+    parser.add_argument("--bound", type=int, help="Factor base bound")
+    parser.add_argument("--interval", type=int, help="Sieve interval")
     args = parser.parse_args(argv)
 
-    factors = gnfs_factor(args.n)
+    cfg = load_config(Path(args.config))
+    degree = args.degree if args.degree is not None else cfg.get("degree", 1)
+    bound = args.bound if args.bound is not None else cfg.get("bound", 30)
+    interval = args.interval if args.interval is not None else cfg.get("interval", 50)
+
+    factors = gnfs_factor(args.n, bound=bound, interval=interval, degree=degree)
     print(f"Factors of {args.n}: {factors}")
     return 0
 

--- a/default_config.json
+++ b/default_config.json
@@ -1,0 +1,5 @@
+{
+  "degree": 1,
+  "bound": 30,
+  "interval": 50
+}

--- a/gnfs/factor.py
+++ b/gnfs/factor.py
@@ -9,10 +9,12 @@ from .sieve import find_relations
 from .sqrt import find_factors
 
 
-def gnfs_factor(n: int, bound: int = 30, interval: int = 50) -> Iterable[int]:
+def gnfs_factor(
+    n: int, bound: int = 30, interval: int = 50, degree: int = 1
+) -> Iterable[int]:
     """Attempt to factor ``n`` using a very small GNFS pipeline."""
 
-    poly = select_polynomial(n)
+    poly = select_polynomial(n, degree=degree)
     primes: List[int] = list(sp.primerange(2, bound + 1))
     relations = list(find_relations(poly, primes=primes, interval=interval))
     return list(find_factors(n, relations, primes))

--- a/gnfs/polynomial/__init__.py
+++ b/gnfs/polynomial/__init__.py
@@ -25,9 +25,18 @@ class Polynomial:
         return result
 
 
-def select_polynomial(n: int) -> Polynomial:
-    """Return a simple polynomial for demonstration purposes."""
-    # In a full GNFS implementation this step is highly complex. Here we
-    # return x - sqrt(n) as a trivial placeholder.
+def select_polynomial(n: int, degree: int = 1) -> Polynomial:
+    """Return a simple polynomial for demonstration purposes.
+
+    Parameters
+    ----------
+    n:
+        Integer to factor.
+    degree:
+        Desired degree of the polynomial.  The current toy implementation only
+        supports degree one and ignores this parameter.
+    """
+    # In a full GNFS implementation this step is highly complex. Here we return
+    # x - sqrt(n) as a trivial placeholder regardless of ``degree``.
     coeffs = (-int(n ** 0.5), 1)
     return Polynomial(coeffs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,6 @@ import cli
 
 
 def test_cli_main_output(capsys):
-    cli.main(["10"])
+    cli.main(["10", "--degree", "1", "--bound", "30", "--interval", "50"])
     captured = capsys.readouterr()
     assert "Factors of 10: [2, 5]" in captured.out


### PR DESCRIPTION
## Summary
- support polynomial degree, factor base bound, and sieve interval in CLI
- read options from default_config.json
- expose degree parameter through `gnfs_factor` and `select_polynomial`
- document CLI options and config usage in README
- mark "Improve the CLI" step as complete in FUTURE_TASKS
- update test for CLI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68741a778718832cacd6c557b4976d9a