### PR TITLE
Enhance GNFS sieve with projective relations

### DIFF
--- a/gnfs/__init__.py
+++ b/gnfs/__init__.py
@@ -1,7 +1,7 @@
 """Simplified General Number Field Sieve implementation."""
 
 from .factor import gnfs_factor
-from .polynomial import Polynomial, select_polynomial
+from .polynomial import Polynomial, PolynomialSelection, select_polynomial
 from .sieve import find_relations, Relation
 from .linalg import solve_matrix
 from .sqrt import find_factors
@@ -9,6 +9,7 @@ from .sqrt import find_factors
 __all__ = [
     "gnfs_factor",
     "Polynomial",
+    "PolynomialSelection",
     "select_polynomial",
     "find_relations",
     "Relation",

--- a/gnfs/factor.py
+++ b/gnfs/factor.py
@@ -32,7 +32,7 @@ def gnfs_factor(
         Degree of the algebraic polynomial used in the sieve.
     """
 
-    poly = select_polynomial(n, degree=degree)
+    selection = select_polynomial(n, degree=degree)
     primes: List[int] = list(sp.primerange(2, bound + 1))
-    relations = list(find_relations(poly, primes=primes, interval=interval))
+    relations = list(find_relations(selection, primes=primes, interval=interval))
     return list(find_factors(n, relations, primes))

--- a/gnfs/linalg/matrix.py
+++ b/gnfs/linalg/matrix.py
@@ -62,8 +62,9 @@ def solve_matrix(relations: Iterable[Relation], primes: List[int]) -> List[List[
     rel_list = list(relations)
     if not rel_list:
         return []
+    combined_factors = [rel.combined_factors() for rel in rel_list]
     exponent_matrix = np.array(
-        [[rel.factors.get(p, 0) % 2 for rel in rel_list] for p in primes],
+        [[factors.get(p, 0) % 2 for factors in combined_factors] for p in primes],
         dtype=int,
     )
     basis = _nullspace_mod2(exponent_matrix)

--- a/gnfs/polynomial/__init__.py
+++ b/gnfs/polynomial/__init__.py
@@ -2,6 +2,12 @@
 
 from .number_field import NumberField, NumberFieldElement
 from .polynomial import Polynomial
-from .selection import select_polynomial
+from .selection import PolynomialSelection, select_polynomial
 
-__all__ = ["Polynomial", "select_polynomial", "NumberField", "NumberFieldElement"]
+__all__ = [
+    "Polynomial",
+    "PolynomialSelection",
+    "select_polynomial",
+    "NumberField",
+    "NumberFieldElement",
+]

--- a/gnfs/polynomial/polynomial.py
+++ b/gnfs/polynomial/polynomial.py
@@ -18,3 +18,12 @@ class Polynomial:
         for power, coeff in enumerate(self.coeffs):
             result += coeff * (x ** power)
         return result
+
+    def evaluate_homogeneous(self, a: int, b: int) -> int:
+        """Evaluate the homogenised polynomial ``b^d f(a / b)``."""
+
+        degree = self.degree()
+        result = 0
+        for power, coeff in enumerate(self.coeffs):
+            result += coeff * (a ** power) * (b ** (degree - power))
+        return result

--- a/gnfs/polynomial/selection.py
+++ b/gnfs/polynomial/selection.py
@@ -11,12 +11,22 @@ algorithm rather than a toy placeholder.
 """
 
 import math
+from dataclasses import dataclass
 from math import comb
 
 from .polynomial import Polynomial
 
 
-def select_polynomial(n: int, degree: int = 1) -> Polynomial:
+@dataclass(frozen=True)
+class PolynomialSelection:
+    """Container bundling the rational and algebraic polynomials for GNFS."""
+
+    algebraic: Polynomial
+    rational: Polynomial
+    m: int
+
+
+def select_polynomial(n: int, degree: int = 1) -> PolynomialSelection:
     """Construct a polynomial with a root ``m`` modulo ``n``.
 
     The selection mirrors the classic ``(x + m)^d - n`` recipe.  The integer
@@ -24,7 +34,10 @@ def select_polynomial(n: int, degree: int = 1) -> Polynomial:
     Expanding ``(x + m)^d`` yields coefficients ``comb(d, k) * m**(d - k)`` for
     ``0 <= k <= d``.  Replacing the constant term with ``m**d - n`` ensures that
     plugging ``x = 0`` into the polynomial gives the small value ``m**d - n`` and
-    that ``x = -m`` is a root modulo ``n``.
+    that ``x = -m`` is a root modulo ``n``.  The returned
+    :class:`PolynomialSelection` additionally bundles the rational-side
+    polynomial ``x - m`` which is used when constructing projective GNFS
+    relations.
 
     Parameters
     ----------
@@ -38,13 +51,15 @@ def select_polynomial(n: int, degree: int = 1) -> Polynomial:
         raise ValueError("degree must be >= 1")
 
     if degree == 1:
-        # Linear case mirrors the rational side polynomial: x - floor(sqrt(n))
-        coeffs = (-int(math.isqrt(n)), 1)
+        m = int(math.isqrt(n))
+        algebraic_coeffs = (-m, 1)
     else:
         # Compute m ≈ n^{1/degree} and expand (x + m)^degree - n
         m = round(n ** (1 / degree))
-        coeffs = [comb(degree, k) * (m ** (degree - k)) for k in range(degree + 1)]
-        coeffs[0] -= n
-        coeffs = tuple(coeffs)
+        algebraic_coeffs = [comb(degree, k) * (m ** (degree - k)) for k in range(degree + 1)]
+        algebraic_coeffs[0] -= n
+        algebraic_coeffs = tuple(algebraic_coeffs)
 
-    return Polynomial(coeffs)
+    algebraic_poly = Polynomial(algebraic_coeffs)
+    rational_poly = Polynomial((-m, 1))
+    return PolynomialSelection(algebraic=algebraic_poly, rational=rational_poly, m=m)

--- a/gnfs/sieve/relation.py
+++ b/gnfs/sieve/relation.py
@@ -10,5 +10,15 @@ class Relation:
 
     a: int
     b: int
-    value: int
-    factors: Dict[int, int]
+    algebraic_value: int
+    rational_value: int
+    algebraic_factors: Dict[int, int]
+    rational_factors: Dict[int, int]
+
+    def combined_factors(self) -> Dict[int, int]:
+        """Return exponent counts from both algebraic and rational sides."""
+
+        combined: Dict[int, int] = dict(self.algebraic_factors)
+        for prime, exponent in self.rational_factors.items():
+            combined[prime] = combined.get(prime, 0) + exponent
+        return combined

--- a/gnfs/sieve/sieve.py
+++ b/gnfs/sieve/sieve.py
@@ -1,17 +1,18 @@
 """Sieving step for the General Number Field Sieve (GNFS).
 
-The sieving phase searches for pairs ``(a, b)`` such that the values
-``b^d f(a / b)`` are ``B``-smooth with respect to a chosen factor base.
-Full GNFS implementations perform lattice sieving with numerous
-optimisations; the routine here keeps to a one-dimensional line sieve but
-follows the same algorithmic ideas:
+The sieving phase searches for pairs ``(a, b)`` such that both the algebraic
+norm ``b^d f(a / b)`` and the rational norm ``a - m b`` are ``B``-smooth with
+respect to a chosen factor base.  Full GNFS implementations perform lattice
+sieving with numerous optimisations; the routine here keeps to a
+one-dimensional line sieve but follows the same algorithmic ideas:
 
 * For each prime ``p`` in the factor base find the roots of the polynomial
   modulo ``p``.
 * Use those roots to mark positions in a sieve array and subtract ``log(p)``
   from the array entries.
 * After all primes have been processed, positions with small residuals are
-  likely smooth and are trial-factored to confirm.
+  likely smooth and are trial-factored on both the algebraic and rational
+  sides to confirm.
 
 Although greatly simplified, this code mirrors the real sieving technique and
 no longer relies on purely toy placeholder logic.
@@ -21,45 +22,78 @@ from typing import Dict, Iterable, List
 
 import math
 
-from ..polynomial import Polynomial
+from ..polynomial import PolynomialSelection
 from .relation import Relation
 from .roots import _polynomial_roots_mod_p
 
 
 def find_relations(
-    poly: Polynomial, primes: List[int], interval: int = 50
+    selection: PolynomialSelection, primes: List[int], interval: int = 50
 ) -> Iterable[Relation]:
     """Find ``B``-smooth relations for ``poly`` using a logarithmic sieve."""
 
+    algebraic_poly = selection.algebraic
+    rational_poly = selection.rational
     offset = interval
-    values = [poly.evaluate(a) for a in range(-interval, interval + 1)]
-    logs = [math.log(abs(v)) if v != 0 else 0.0 for v in values]
 
-    for p in primes:
-        logp = math.log(p)
-        for r in _polynomial_roots_mod_p(poly, p):
-            start = (-interval + ((r - (-interval)) % p))
-            for a in range(start, interval + 1, p):
-                idx = a + offset
-                while values[idx] != 0 and values[idx] % p == 0:
-                    values[idx] //= p
-                    logs[idx] -= logp
-
-    for idx, a in enumerate(range(-interval, interval + 1)):
-        if abs(values[idx]) == 1 and logs[idx] < 1e-5:
-            val = poly.evaluate(a)
-            if val == 0:
-                continue
-            remaining = abs(val)
-            factor_exp: Dict[int, int] = {}
-            for p in primes:
-                if remaining == 1:
-                    break
-                exp = 0
-                while remaining % p == 0:
-                    exp += 1
-                    remaining //= p
-                if exp:
-                    factor_exp[p] = exp
+    def _trial_factor(value: int) -> tuple[int, Dict[int, int]]:
+        remaining = abs(value)
+        factors: Dict[int, int] = {}
+        for p in primes:
             if remaining == 1:
-                yield Relation(a=a, b=1, value=val, factors=factor_exp)
+                break
+            exp = 0
+            while remaining % p == 0:
+                remaining //= p
+                exp += 1
+            if exp:
+                factors[p] = exp
+        return remaining, factors
+
+    for b in range(1, interval + 1):
+        values = [
+            algebraic_poly.evaluate_homogeneous(a, b) for a in range(-interval, interval + 1)
+        ]
+        logs = [math.log(abs(v)) if v != 0 else 0.0 for v in values]
+
+        for p in primes:
+            logp = math.log(p)
+            roots = _polynomial_roots_mod_p(algebraic_poly, p)
+            if not roots:
+                continue
+            for root in roots:
+                target = (root * b) % p
+                start = -interval + ((target - (-interval)) % p)
+                for a in range(start, interval + 1, p):
+                    idx = a + offset
+                    while values[idx] != 0 and values[idx] % p == 0:
+                        values[idx] //= p
+                        logs[idx] -= logp
+
+        for idx, a in enumerate(range(-interval, interval + 1)):
+            if math.gcd(a, b) != 1:
+                continue
+            if abs(values[idx]) != 1 or logs[idx] > 1e-5:
+                continue
+
+            algebraic_value = algebraic_poly.evaluate_homogeneous(a, b)
+            rational_value = rational_poly.evaluate_homogeneous(a, b)
+            if algebraic_value == 0 or rational_value == 0:
+                continue
+
+            remaining_alg, algebraic_factors = _trial_factor(algebraic_value)
+            if remaining_alg != 1:
+                continue
+
+            remaining_rat, rational_factors = _trial_factor(rational_value)
+            if remaining_rat != 1:
+                continue
+
+            yield Relation(
+                a=a,
+                b=b,
+                algebraic_value=algebraic_value,
+                rational_value=rational_value,
+                algebraic_factors=algebraic_factors,
+                rational_factors=rational_factors,
+            )

--- a/gnfs/sqrt/square_root.py
+++ b/gnfs/sqrt/square_root.py
@@ -25,8 +25,8 @@ def find_factors(n: int, relations: Iterable[Relation], primes: List[int]) -> It
         prod = 1
         for idx in dep:
             rel = rel_list[idx]
-            x = (x * rel.a) % n
-            prod *= abs(rel.value)
+            x = (x * (rel.rational_value % n)) % n
+            prod *= abs(rel.algebraic_value)
         y = isqrt(prod)
         if y * y != prod:
             # Should not happen if exponents are even, but be safe

--- a/tests/test_linear_algebra.py
+++ b/tests/test_linear_algebra.py
@@ -1,4 +1,6 @@
 import numpy as np
+import numpy as np
+
 from gnfs.linalg.matrix import _nullspace_mod2, solve_matrix
 from gnfs.sieve.relation import Relation
 
@@ -6,8 +8,22 @@ from gnfs.sieve.relation import Relation
 def test_solve_matrix_returns_dependency():
     primes = [2]
     relations = [
-        Relation(a=1, b=1, value=2, factors={2: 1}),
-        Relation(a=2, b=1, value=2, factors={2: 1}),
+        Relation(
+            a=1,
+            b=1,
+            algebraic_value=2,
+            rational_value=1,
+            algebraic_factors={2: 1},
+            rational_factors={},
+        ),
+        Relation(
+            a=2,
+            b=1,
+            algebraic_value=2,
+            rational_value=1,
+            algebraic_factors={2: 1},
+            rational_factors={},
+        ),
     ]
     deps = solve_matrix(relations, primes)
     assert deps == [[0, 1]]
@@ -33,9 +49,30 @@ def test_solve_matrix_no_relations():
 def test_solve_matrix_multiple_primes_dependency():
     primes = [2, 3]
     relations = [
-        Relation(a=1, b=1, value=2, factors={2: 1}),
-        Relation(a=1, b=1, value=3, factors={3: 1}),
-        Relation(a=1, b=1, value=6, factors={2: 1, 3: 1}),
+        Relation(
+            a=1,
+            b=1,
+            algebraic_value=2,
+            rational_value=1,
+            algebraic_factors={2: 1},
+            rational_factors={},
+        ),
+        Relation(
+            a=1,
+            b=1,
+            algebraic_value=3,
+            rational_value=1,
+            algebraic_factors={3: 1},
+            rational_factors={},
+        ),
+        Relation(
+            a=1,
+            b=1,
+            algebraic_value=6,
+            rational_value=1,
+            algebraic_factors={2: 1, 3: 1},
+            rational_factors={},
+        ),
     ]
     deps = solve_matrix(relations, primes)
     assert deps == [[0, 1, 2]]

--- a/tests/test_polynomial.py
+++ b/tests/test_polynomial.py
@@ -1,6 +1,9 @@
 import pytest
 from gnfs.polynomial.polynomial import Polynomial
-from gnfs.polynomial.selection import select_polynomial
+import pytest
+
+from gnfs.polynomial.polynomial import Polynomial
+from gnfs.polynomial.selection import PolynomialSelection, select_polynomial
 
 
 def test_polynomial_evaluate_and_degree():
@@ -12,14 +15,16 @@ def test_polynomial_evaluate_and_degree():
 
 
 def test_select_polynomial_degree_one():
-    poly = select_polynomial(10, degree=1)
-    assert isinstance(poly, Polynomial)
-    assert poly.coeffs == (-int(10 ** 0.5), 1)
+    selection = select_polynomial(10, degree=1)
+    assert isinstance(selection, PolynomialSelection)
+    assert selection.algebraic.coeffs == (-int(10 ** 0.5), 1)
+    assert selection.rational.coeffs == (-int(10 ** 0.5), 1)
 
 
 def test_select_polynomial_higher_degree():
-    poly = select_polynomial(10, degree=3)
-    assert isinstance(poly, Polynomial)
+    selection = select_polynomial(10, degree=3)
+    assert isinstance(selection, PolynomialSelection)
+    poly = selection.algebraic
     assert poly.degree() == 3
     # For n=10 and degree=3 we expect the (x + m)^3 - n construction
     # where m = round(n ** (1/3)) = 2, leading to coefficients
@@ -40,6 +45,7 @@ def test_polynomial_constant_degree_zero():
 
 def test_select_polynomial_root_property():
     n = 10
-    poly = select_polynomial(n, degree=2)
-    m = round(n ** 0.5)
-    assert poly.evaluate(-m) % n == 0
+    selection = select_polynomial(n, degree=2)
+    m = selection.m
+    assert selection.algebraic.evaluate(-m) % n == 0
+    assert selection.rational.evaluate(m) == 0

--- a/tests/test_sieve.py
+++ b/tests/test_sieve.py
@@ -24,13 +24,18 @@ def test_polynomial_roots_mod_p_repeated_root():
 
 
 def test_find_relations_produces_smooth_values():
-    poly = select_polynomial(10)
+    selection = select_polynomial(10)
     primes = list(sp.primerange(2, 6))
-    relations = list(find_relations(poly, primes=primes, interval=5))
+    relations = list(find_relations(selection, primes=primes, interval=5))
     assert relations, "Expected at least one relation"
     for rel in relations:
-        value = abs(rel.value)
-        for p, exp in rel.factors.items():
+        value = abs(rel.algebraic_value)
+        for p, exp in rel.algebraic_factors.items():
             for _ in range(exp):
                 value //= p
         assert value == 1
+        rat = abs(rel.rational_value)
+        for p, exp in rel.rational_factors.items():
+            for _ in range(exp):
+                rat //= p
+        assert rat == 1

--- a/tests/test_square_root.py
+++ b/tests/test_square_root.py
@@ -6,15 +6,24 @@ from gnfs.sqrt.square_root import find_factors
 
 
 def test_find_factors_even_number():
-    poly = select_polynomial(10)
+    selection = select_polynomial(10)
     primes = list(sp.primerange(2, 6))
-    relations = list(find_relations(poly, primes=primes, interval=5))
+    relations = list(find_relations(selection, primes=primes, interval=5))
     factors = list(find_factors(10, relations, primes))
     assert factors == [2, 5]
 
 
 def test_find_factors_no_dependencies():
     n = 10
-    relations = [Relation(a=1, b=1, value=2, factors={2: 1})]
+    relations = [
+        Relation(
+            a=1,
+            b=1,
+            algebraic_value=2,
+            rational_value=1,
+            algebraic_factors={2: 1},
+            rational_factors={},
+        )
+    ]
     factors = list(find_factors(n, relations, [2]))
     assert factors == []


### PR DESCRIPTION
## Summary
- bundle rational and algebraic polynomials into a PolynomialSelection object
- extend the sieving step to search projective (a, b) pairs and record both algebraic and rational smoothness data
- adapt downstream linear algebra, square root, and tests to consume the richer relation information

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68f5345fc832ca8da4c766b3e34dd